### PR TITLE
Change visibility of newGaFeed function.

### DIFF
--- a/src/GoogleAnalyticsCounterCommon.php
+++ b/src/GoogleAnalyticsCounterCommon.php
@@ -118,7 +118,7 @@ class GoogleAnalyticsCounterCommon {
    *   GoogleAnalyticsCounterFeed object to authorize access and request data
    *   from the Google Analytics Core Reporting API.
    */
-  protected function newGaFeed() {
+  public function newGaFeed() {
     $config = $this->config;
 
     if ($this->state->get('google_analytics_counter.access_token') && time() < $this->state->get('google_analytics_counter.expires_at')) {


### PR DESCRIPTION
On `/admin/config/system/google-analytics-counter/authentication` I get following error: `Error: Call to protected method Drupal\google_analytics_counter\GoogleAnalyticsCounterCommon::newGaFeed() from context 'Drupal\google_analytics_counter\Form\GoogleAnalyticsCounterAdminAuthForm' in Drupal\google_analytics_counter\Form\GoogleAnalyticsCounterAdminAuthForm->buildForm() (line 30 of modules/contrib/google_analytics_counter/src/Form/GoogleAnalyticsCounterAdminAuthForm.php).`

This can be resolved by changing visibility of `Drupal\google_analytics_counter\GoogleAnalyticsCounterCommon::newGaFeed()` to public as in this pull request.

There is also opened issue for this https://github.com/bircher/drupal-google_analytics_counter/issues/2